### PR TITLE
Supporting custom containerd shim runtime

### DIFF
--- a/api/types/types.go
+++ b/api/types/types.go
@@ -521,13 +521,13 @@ type Runtime struct {
 
 	// This is exposed here only for internal use
 	// It is not currently supported to specify custom shim configs
-	Shim *ShimConfig `json:"-"`
+	Shim *ShimConfig `json:"shim"`
 }
 
 // ShimConfig is used by runtime to configure containerd shims
 type ShimConfig struct {
-	Binary string
-	Opts   interface{}
+	Binary string      `json:"binary"`
+	Opts   interface{} `json:"opts"`
 }
 
 // DiskUsage contains response of Engine API:


### PR DESCRIPTION
Currently docker doesn't support custom shim runtime when creating daemon and containers. Custom runtime shim configuration is also disabled.  This PR is mean to enable the support for custom shim runtime and shim config through docker configuration(as in daemon.json).

Related issues:
1. https://github.com/moby/moby/issues/42239

**- What I did and How I did it**
1. Make json struct tag of Shim field of api/types.Runtime public, so we can config it through daemon.json.
2. A modification to daemon/runtime_unix.(func initRuntimes), when runtime is being initializing, read the opts in the form of map[string]interface{} and convert it to a real struct implementation
**- How to verify it**
1. Run dockerd with the following configuration(you may need other custom containerd runtime if you are not meant to run with eru-containerd)
```json
{
  "pidfile": "/run/eru/docker.pid",
  "data-root": "/var/lib/eru/docker",
  "exec-root": "/var/run/eru/docker",
  "live-restore": true,
  "containerd": "/run/eru/containerd.sock",
  "containerd-namespace": "io.containerd.eru.v2",
  "hosts": [
    "unix:///var/run/eru/docker.sock"
  ],
  "runtimes": {
    "io.containerd.eru.v2": {
      "path": "runc",
      "shim": {
        "binary": "io.containerd.eru.v2"
      }
    }
  }
}
```
**- Verification**
1. create a container with custom runtime, and you will find the container is successfully created and can be started
```shell
 docker -H unix:///var/run/eru/docker.sock container create --runtime io.containerd.eru.v2 nginx:latest
```
**- Description for the changelog**
```
api/types.go // add shim json struct tag
daemon/runtime_unix.go // add initializing logic for custom shim runtime
```